### PR TITLE
Protect resources using terraform precondition instead of postcondition

### DIFF
--- a/core/main.tf
+++ b/core/main.tf
@@ -206,13 +206,6 @@ resource "oci_vault_secret" "cluster_node_count" {
 # This item acts a barrier to prevent inadvertant node removal before the cluster has successfully removed nodes from membership
 data "external" "cluster_node_count" {
   program = concat(local.retrieve_stored_value_sh, [oci_vault_secret.cluster_node_count.id])
-
-  lifecycle {
-    postcondition {
-      condition     = tonumber(self.result.value) <= var.q_node_count
-      error_message = "Lowering the number of deployed nodes (q_node_count) is only supported after removing the extra nodes from the cluster membership."
-    }
-  }
 }
 
 resource "oci_vault_secret" "deployed_permanent_disk_count" {
@@ -313,6 +306,7 @@ module "qcluster" {
   node_count           = var.q_node_count
   permanent_disk_count = local.permanent_disk_count
   floating_ip_count    = var.q_cluster_floating_ips
+  persisted_node_count = tonumber(data.external.cluster_node_count.result.value)
 
   node_instance_shape = var.node_instance_shape
   node_instance_ocpus = var.node_instance_ocpus
@@ -334,7 +328,6 @@ module "qcluster" {
   freeform_tags = var.freeform_tags
 
   depends_on = [
-    data.external.cluster_node_count,
     data.external.deployed_permanent_disk_count,
     oci_identity_policy.cluster_policy,
     oci_identity_policy.instance_policy

--- a/core/main.tf
+++ b/core/main.tf
@@ -232,13 +232,6 @@ resource "oci_vault_secret" "deployed_permanent_disk_count" {
 
 data "external" "deployed_permanent_disk_count" {
   program = concat(local.retrieve_stored_value_sh, [oci_vault_secret.deployed_permanent_disk_count.id])
-
-  lifecycle {
-    postcondition {
-      condition     = tonumber(self.result.value) == 0 || tonumber(self.result.value) == local.permanent_disk_count
-      error_message = "Modifying the permanent disk count via variable block_volume_count is not supported after the initial deployment."
-    }
-  }
 }
 
 resource "oci_vault_secret" "cluster_soft_capacity_limit" {
@@ -307,6 +300,7 @@ module "qcluster" {
   permanent_disk_count = local.permanent_disk_count
   floating_ip_count    = var.q_cluster_floating_ips
   persisted_node_count = tonumber(data.external.cluster_node_count.result.value)
+  persisted_disk_count = tonumber(data.external.deployed_permanent_disk_count.result.value)
 
   node_instance_shape = var.node_instance_shape
   node_instance_ocpus = var.node_instance_ocpus
@@ -328,7 +322,6 @@ module "qcluster" {
   freeform_tags = var.freeform_tags
 
   depends_on = [
-    data.external.deployed_permanent_disk_count,
     oci_identity_policy.cluster_policy,
     oci_identity_policy.instance_policy
   ]

--- a/core/modules/qcluster-disk/main.tf
+++ b/core/modules/qcluster-disk/main.tf
@@ -35,6 +35,11 @@ resource "oci_core_volume" "permanent_disk" {
   lifecycle {
     # Any disk property changes after the initial deployment are ignored
     ignore_changes = [availability_domain, compartment_id, size_in_gbs, vpus_per_gb]
+
+    precondition {
+      condition     = var.persisted_disk_count == 0 || var.persisted_disk_count == var.disk_count
+      error_message = "Modifying the permanent disk count via variable block_volume_count is not supported after the initial deployment."
+    }
   }
 }
 

--- a/core/modules/qcluster-disk/variables.tf
+++ b/core/modules/qcluster-disk/variables.tf
@@ -27,6 +27,11 @@ variable "disk_count" {
   type        = string
 }
 
+variable "persisted_disk_count" {
+  description = "The number of permanent disks per node in the already created cluster."
+  type        = number
+}
+
 variable "availability_domain" {
   description = "The availability domain to be used for the cluster resources."
   type        = string

--- a/core/modules/qcluster/main.tf
+++ b/core/modules/qcluster/main.tf
@@ -136,6 +136,7 @@ module "disk" {
   instance_id            = oci_core_instance.node[count.index].id
   node_id                = count.index
   disk_count             = var.permanent_disk_count
+  persisted_disk_count   = var.persisted_disk_count
   size_in_gbs            = "270"
   vpus_per_gb            = "10"
   defined_tags           = var.defined_tags

--- a/core/modules/qcluster/main.tf
+++ b/core/modules/qcluster/main.tf
@@ -74,10 +74,6 @@ resource "oci_core_instance" "node" {
     }))
     "ssh_authorized_keys" = join("\n", local.ssh_public_key_contents)
   }
-
-  lifecycle {
-    ignore_changes = [metadata, availability_domain, fault_domain, source_details]
-  }
   shape = var.node_instance_shape
   shape_config {
     ocpus = var.node_instance_ocpus
@@ -87,6 +83,15 @@ resource "oci_core_instance" "node" {
     source_type             = "image"
     boot_volume_size_in_gbs = 256
     boot_volume_vpus_per_gb = 30
+  }
+
+  lifecycle {
+    ignore_changes = [metadata, availability_domain, fault_domain, source_details]
+
+    precondition {
+      condition     = var.persisted_node_count <= var.node_count
+      error_message = "Lowering the number of deployed nodes (q_node_count) is only supported after removing the extra nodes from the cluster membership via q_cluster_node_count."
+    }
   }
 }
 

--- a/core/modules/qcluster/variables.tf
+++ b/core/modules/qcluster/variables.tf
@@ -57,6 +57,11 @@ variable "floating_ip_count" {
   type        = number
 }
 
+variable "persisted_node_count" {
+  description = "The number of Qumulo nodes in the already created cluster."
+  type        = number
+}
+
 variable "node_instance_shape" {
   description = "The VM shape to use for the Qumulo nodes."
   type        = string

--- a/core/modules/qcluster/variables.tf
+++ b/core/modules/qcluster/variables.tf
@@ -62,6 +62,11 @@ variable "persisted_node_count" {
   type        = number
 }
 
+variable "persisted_disk_count" {
+  description = "The number of permanent disks per node in the already created cluster."
+  type        = number
+}
+
 variable "node_instance_shape" {
   description = "The VM shape to use for the Qumulo nodes."
   type        = string


### PR DESCRIPTION
During the apply phase, a failed precondition will prevent Terraform from implementing planned actions for the associated resource. However, a failed postcondition will halt processing after Terraform has already implemented these actions. The failed postcondition prevents any further downstream actions that rely on the resource, but does not undo the actions Terraform has already taken.