### PR TITLE
Clean up the qumulo-core.rpm object before attempting to form the cluster

### DIFF
--- a/core/main.tf
+++ b/core/main.tf
@@ -73,6 +73,8 @@ resource "null_resource" "name_lock" {
 
 locals {
   cluster_email          = "${local.deployment_unique_name}-user@qumulo.com"
+  qumulo_core_rpm_bucket_name = (var.qumulo_core_rpm_path != null) ?  var.persistent_storage.bucket[0].name : ""
+  qumulo_core_rpm_object_name = (var.qumulo_core_rpm_path != null) ?  oci_objectstorage_object.qumulo_core[0].object : ""
   qumulo_core_object_uri = (var.qumulo_core_rpm_url != null) ? var.qumulo_core_rpm_url : "https://objectstorage.${var.persistent_storage.bucket_region}.oraclecloud.com${oci_objectstorage_preauthrequest.qumulo_core[0].access_uri}"
   deployment_unique_name = null_resource.name_lock.triggers.deployment_unique_name
 }
@@ -358,6 +360,8 @@ module "qprovisioner" {
   cluster_node_count_secret_id            = oci_vault_secret.cluster_node_count.id
   deployed_permanent_disk_count_secret_id = oci_vault_secret.deployed_permanent_disk_count.id
   cluster_soft_capacity_limit_secret_id   = oci_vault_secret.cluster_soft_capacity_limit.id
+  qumulo_core_rpm_bucket_name     = local.qumulo_core_rpm_bucket_name
+  qumulo_core_rpm_object_name     = local.qumulo_core_rpm_object_name
 
   dev_environment = var.dev_environment
   defined_tags    = var.defined_tags

--- a/core/modules/qprovisioner/main.tf
+++ b/core/modules/qprovisioner/main.tf
@@ -75,6 +75,8 @@ resource "oci_core_instance" "provisioner" {
       cluster_node_count_secret_id            = var.cluster_node_count_secret_id
       deployed_permanent_disk_count_secret_id = var.deployed_permanent_disk_count_secret_id
       cluster_soft_capacity_limit_secret_id   = var.cluster_soft_capacity_limit_secret_id
+      qumulo_core_rpm_bucket_name             = var.qumulo_core_rpm_bucket_name
+      qumulo_core_rpm_object_name             = var.qumulo_core_rpm_object_name
       dev_environment                         = var.dev_environment
     }))
     "ssh_authorized_keys" = join("\n", local.ssh_public_key_contents)

--- a/core/modules/qprovisioner/scripts/provision.py
+++ b/core/modules/qprovisioner/scripts/provision.py
@@ -47,6 +47,8 @@ import requests
 # Template variables (replaced by Terraform templatefile)
 cluster_node_ip_addresses = "${cluster_node_ip_addresses}"
 clustering_node_ip_address = "${clustering_node_ip_address}"
+qumulo_core_rpm_bucket_name="${qumulo_core_rpm_bucket_name}"
+qumulo_core_rpm_object_name="${qumulo_core_rpm_object_name}"
 
 
 @dataclass
@@ -169,6 +171,17 @@ def wait_for_qfsd_installation(cluster_node_ip_addresses: str) -> None:
 
             logging.info(f"Waiting for QFSD to be up and running on node {ip}")
             time.sleep(10)
+
+
+def clean_up_qumulo_core_rpm(bucket_name: str, object_name: str) -> None:
+    if bucket_name != "" and object_name != "":
+        # If the object does not exist in the bucket, don't let that fail provisioning. If it fails
+        # to be deleted, qfsd will catch it later when the cluster is formed.
+        run_command(
+            f'/root/bin/oci os object delete --bucket-name "{bucket_name}" --object-name "{object_name}"'
+            "--auth instance_principal",
+            check=False
+        )
 
 
 def get_qfsd_version(ip: str) -> str:
@@ -524,6 +537,7 @@ def main() -> None:
     os.chdir("/root")
     install_oci_cli()
     wait_for_qfsd_installation(cluster_node_ip_addresses)
+    clean_up_qumulo_core_rpm(qumulo_core_rpm_bucket_name, qumulo_core_rpm_object_name)
     download_qq_client()
 
     qfsd_version = get_qfsd_version(clustering_node_ip_address)

--- a/core/modules/qprovisioner/variables.tf
+++ b/core/modules/qprovisioner/variables.tf
@@ -152,6 +152,16 @@ variable "cluster_soft_capacity_limit_secret_id" {
   type        = string
 }
 
+variable "qumulo_core_rpm_bucket_name" {
+  description = "The bucket name of the RPM used to install Qumulo Core on the nodes, for the purpose of cleaning up the object before creating the cluster."
+  type        = string
+}
+
+variable "qumulo_core_rpm_object_name" {
+  description = "The object name of the RPM used to install Qumulo Core on the nodes, for the purpose of cleaning up the object before creating the cluster."
+  type        = string
+}
+
 variable "defined_tags" {
   description = "Defined tags to apply to all resources. Should be in the format { \"namespace.key\" = \"value\" }"
   type        = map(string)


### PR DESCRIPTION
QFSD will in the future check if the persistent-storage buckets are empty first before allowing a cluster to be formed. Allowing the qumulo-core.rpm object to live in the bucket forever will cause clustering to fail on OCI.