### PR TITLE
Fix OCI provisioning issues

### DIFF
--- a/core/modules/qprovisioner/main.tf
+++ b/core/modules/qprovisioner/main.tf
@@ -76,8 +76,6 @@ resource "oci_core_instance" "provisioner" {
       deployed_permanent_disk_count_secret_id = var.deployed_permanent_disk_count_secret_id
       cluster_soft_capacity_limit_secret_id   = var.cluster_soft_capacity_limit_secret_id
       provisioner_complete_secret_id          = var.provisioner_complete_secret_id
-      qumulo_core_rpm_bucket_name             = var.qumulo_core_rpm_bucket_name
-      qumulo_core_rpm_object_name             = var.qumulo_core_rpm_object_name
       dev_environment                         = var.dev_environment
     }))
     "ssh_authorized_keys" = join("\n", local.ssh_public_key_contents)

--- a/core/modules/qprovisioner/scripts/provision.py
+++ b/core/modules/qprovisioner/scripts/provision.py
@@ -40,15 +40,12 @@ import re
 import subprocess
 import time
 from dataclasses import dataclass
-from pathlib import Path
-from typing import List, Dict, Optional, Tuple
+from typing import List, Optional, Tuple
 import requests
 
 # Template variables (replaced by Terraform templatefile)
 cluster_node_ip_addresses = "${cluster_node_ip_addresses}"
 clustering_node_ip_address = "${clustering_node_ip_address}"
-qumulo_core_rpm_bucket_name = "${qumulo_core_rpm_bucket_name}"
-qumulo_core_rpm_object_name = "${qumulo_core_rpm_object_name}"
 
 
 @dataclass
@@ -174,16 +171,6 @@ def wait_for_qfsd_installation(cluster_node_ip_addresses: str) -> None:
 
             logging.info(f"Waiting for QFSD to be up and running on node {ip}")
             time.sleep(10)
-
-
-def clean_up_qumulo_core_rpm(bucket_name: str, object_name: str) -> None:
-    if bucket_name != "" and object_name != "":
-        # If the object does not exist in the bucket, don't let that fail provisioning. If it fails
-        # to be deleted, qfsd will catch it later when the cluster is formed.
-        run_command(
-            f'/root/bin/oci os object delete --bucket-name "{bucket_name}" --object-name "{object_name}"'
-            "--auth instance_principal",
-        )
 
 
 def get_qfsd_version(ip: str) -> str:
@@ -547,7 +534,6 @@ def main() -> None:
     os.chdir("/root")
     install_oci_cli()
     wait_for_qfsd_installation(cluster_node_ip_addresses)
-    clean_up_qumulo_core_rpm(qumulo_core_rpm_bucket_name, qumulo_core_rpm_object_name)
     download_qq_client()
 
     qfsd_version = get_qfsd_version(clustering_node_ip_address)

--- a/core/modules/qprovisioner/scripts/wait_for_completion.sh
+++ b/core/modules/qprovisioner/scripts/wait_for_completion.sh
@@ -47,3 +47,7 @@ while true; do
     sleep 30
 done
 echo "Cluster provisioning complete"
+
+oci vault secret update-base64 \
+    --secret-id $secret_id \
+    --secret-content-content "$(echo -n false | base64)"

--- a/core/modules/qprovisioner/variables.tf
+++ b/core/modules/qprovisioner/variables.tf
@@ -157,16 +157,6 @@ variable "provisioner_complete_secret_id" {
   type        = string
 }
 
-variable "qumulo_core_rpm_bucket_name" {
-  description = "The bucket name of the RPM used to install Qumulo Core on the nodes, for the purpose of cleaning up the object before creating the cluster."
-  type        = string
-}
-
-variable "qumulo_core_rpm_object_name" {
-  description = "The object name of the RPM used to install Qumulo Core on the nodes, for the purpose of cleaning up the object before creating the cluster."
-  type        = string
-}
-
 variable "defined_tags" {
   description = "Defined tags to apply to all resources. Should be in the format { \"namespace.key\" = \"value\" }"
   type        = map(string)

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -187,24 +187,10 @@ variable "vault_ocid" {
   }
 }
 
-variable "qumulo_core_rpm_path" {
-  description = "The local path to the qumulo-core.rpm file for the version of Qumulo you want to install."
-  type        = string
-  nullable    = true
-
-  validation {
-    condition = (
-      (var.qumulo_core_rpm_path == null && var.qumulo_core_rpm_url != null) ||
-      (var.qumulo_core_rpm_path != null && var.qumulo_core_rpm_url == null)
-    )
-    error_message = "Exactly one of qumulo_core_rpm_path or qumulo_core_rpm_url must be set."
-  }
-}
-
 variable "qumulo_core_rpm_url" {
   description = "A URL accessible to the instances pointing to the qumulo-core.rpm object for the version of Qumulo you want to install."
   type        = string
-  nullable    = true
+  nullable    = false
 }
 
 variable "q_cluster_admin_password" {

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,6 @@ module "core" {
   assign_public_ip                         = var.assign_public_ip
   block_volume_count                       = var.block_volume_count
   vault_ocid                               = var.vault_ocid
-  qumulo_core_rpm_path                     = var.qumulo_core_rpm_path
   qumulo_core_rpm_url                      = var.qumulo_core_rpm_url
   q_cluster_admin_password                 = var.q_cluster_admin_password
   q_cluster_floating_ips                   = var.q_cluster_floating_ips

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -10,7 +10,8 @@
 # q_cluster_admin_password     - Minumum 8 characters and must include one each of: uppercase, lowercase, and a special character.  If replacing a cluster make sure this password matches current running cluster.
 # node_ssh_public_key_paths    - List of paths to the pre-created admin public key files that should be installed on the OCI virtual machines running Qumulo
 # node_ssh_public_key_strings  - List of pre-created admin public keys that should be installed on the OCI virtual machines running Qumulo
-#  node_ssh_public_key_paths and node_ssh_public_key_strings can be used together or separately, but at least one must be set.
+# node_ssh_public_key_paths and node_ssh_public_key_strings can be used together or separately, but at least one must be set.
+# qumulo_core_rpm_url          - URL to object storing a qumulo-qcore.rpm file
 
 region                      = "my_region"
 availability_domain         = null
@@ -22,13 +23,7 @@ q_cluster_name              = "my_cluster"
 q_cluster_admin_password    = "my_password"
 node_ssh_public_key_paths   = ["my_public_key_file_path", ]
 node_ssh_public_key_strings = ["my_public_key_string", ]
-
-# Set exactly one of the following variables:
-# qumulo_core_rpm_path      - Local path to the downloaded qumulo-qcore.rpm file.
-# qumulo_core_rpm_url       - URL to object storing a qumulo-qcore.rpm file
-
-qumulo_core_rpm_path = "my_rpm_path"
-qumulo_core_rpm_url  = null
+qumulo_core_rpm_url         = "my_rpm_url"
 
 #
 # ****************************** Advanced Configurations **********************************************

--- a/variables.tf
+++ b/variables.tf
@@ -239,26 +239,10 @@ variable "persistent_storage_vault_ocid" {
   }
 }
 
-variable "qumulo_core_rpm_path" {
-  description = "The local path to the qumulo-core.rpm file for the version of Qumulo you want to install."
-  type        = string
-  nullable    = true
-  default     = null
-
-  validation {
-    condition = (
-      (var.qumulo_core_rpm_path == null && var.qumulo_core_rpm_url != null) ||
-      (var.qumulo_core_rpm_path != null && var.qumulo_core_rpm_url == null)
-    )
-    error_message = "Exactly one of qumulo_core_rpm_path or qumulo_core_rpm_url must be set."
-  }
-}
-
 variable "qumulo_core_rpm_url" {
   description = "A URL accessible to the instances pointing to the qumulo-core.rpm object for the version of Qumulo you want to install."
   type        = string
-  nullable    = true
-  default     = null
+  nullable    = false
 }
 
 variable "q_cluster_admin_password" {


### PR DESCRIPTION
This PR fixes two issues with provisioning on OCI:
1. Waits for provisioning to complete before returning from a subsequent terraform apply
2. Removes the option to provide a local rpm path, which was broken