### PR TITLE
Add node_base_image variable to overwrite the base image selection.

### DIFF
--- a/core/main.tf
+++ b/core/main.tf
@@ -283,6 +283,21 @@ resource "oci_vault_secret" "provisioner_complete" {
 data "oci_core_subnet" "subnet" {
   subnet_id = var.subnet_ocid
 }
+
+data "oci_core_images" "latest" {
+  compartment_id           = var.compartment_ocid
+  operating_system         = "Oracle Linux"
+  operating_system_version = "9"
+  shape                    = var.node_instance_shape
+  state                    = "AVAILABLE"
+  sort_by                  = "DISPLAYNAME"
+  sort_order               = "DESC"
+}
+
+locals {
+  node_base_image = var.node_base_image != null ? var.node_base_image : data.oci_core_images.latest.images[0].id
+}
+
 module "qcluster" {
   source = "./modules/qcluster"
 
@@ -300,6 +315,7 @@ module "qcluster" {
 
   node_instance_shape = var.node_instance_shape
   node_instance_ocpus = var.node_instance_ocpus
+  node_base_image     = local.node_base_image
   assign_public_ip    = var.assign_public_ip
 
   node_ssh_public_key_paths   = var.node_ssh_public_key_paths

--- a/core/modules/qcluster/main.tf
+++ b/core/modules/qcluster/main.tf
@@ -37,16 +37,6 @@ locals {
   fault_domains       = data.oci_identity_fault_domains.fault_domains.fault_domains
 }
 
-data "oci_core_images" "base_image" {
-  compartment_id           = var.compartment_ocid
-  operating_system         = "Oracle Linux"
-  operating_system_version = "9"
-  shape                    = var.node_instance_shape
-  state                    = "AVAILABLE"
-  sort_by                  = "DISPLAYNAME"
-  sort_order               = "DESC"
-}
-
 resource "oci_core_instance" "node" {
   count               = var.node_count
   compartment_id      = var.compartment_ocid
@@ -79,7 +69,7 @@ resource "oci_core_instance" "node" {
     ocpus = var.node_instance_ocpus
   }
   source_details {
-    source_id               = data.oci_core_images.base_image.images[0].id
+    source_id               = var.node_base_image
     source_type             = "image"
     boot_volume_size_in_gbs = 256
     boot_volume_vpus_per_gb = 30

--- a/core/modules/qcluster/variables.tf
+++ b/core/modules/qcluster/variables.tf
@@ -77,6 +77,12 @@ variable "node_instance_ocpus" {
   type        = number
 }
 
+variable "node_base_image" {
+  description = "The OCID of the image used to launch the node instances. Must be compatible with the chosen node instance shape."
+  type        = string
+  nullable    = false
+}
+
 variable "assign_public_ip" {
   description = "Enable/disable the use of public IP addresses on the cluster and provisioning node.  Cluster still requires outbound internet access to function."
   type        = bool

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -160,6 +160,12 @@ variable "node_instance_ocpus" {
   default     = 8
 }
 
+variable "node_base_image" {
+  description = "The OCID of the image used to launch node instances. Must be compatible with the chosen node instance shape. Leave null to use the latest release Oracle Linux 9 image."
+  type        = string
+  nullable    = true
+}
+
 variable "assign_public_ip" {
   description = "Enable/disable the use of public IP addresses on the cluster and provisioning node.  Cluster still requires outbound internet access to function."
   type        = bool

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ module "core" {
   q_cluster_cold                           = var.q_cluster_cold
   node_instance_shape                      = var.node_instance_shape
   node_instance_ocpus                      = var.node_instance_ocpus
+  node_base_image                          = var.node_base_image
   assign_public_ip                         = var.assign_public_ip
   block_volume_count                       = var.block_volume_count
   vault_ocid                               = var.vault_ocid

--- a/variables.tf
+++ b/variables.tf
@@ -202,6 +202,12 @@ variable "node_instance_ocpus" {
   default     = 8
 }
 
+variable "node_base_image" {
+  description = "The OCID of the image used to launch node instances. Must be compatible with the chosen node instance shape. Leave null to use the latest release Oracle Linux 9 image."
+  type        = string
+  nullable    = true
+}
+
 variable "assign_public_ip" {
   description = "Enable/disable the use of public IP addresses on the cluster and provisioning node.  Cluster still requires outbound internet access to function."
   type        = bool


### PR DESCRIPTION
Since we're seeing some issues with the latest Oracle Linux 9 image, this will make sure we have a workaround until we know can fix what's going on there.