### PR TITLE
Raise cluster provisioning timeout to 30 minutes

### DIFF
--- a/core/modules/qprovisioner/scripts/wait_for_completion.sh
+++ b/core/modules/qprovisioner/scripts/wait_for_completion.sh
@@ -25,7 +25,7 @@
 
 secret_id="${secret_id}"
 
-max_retries=30
+max_retries=60
 count=0
 
 while true; do


### PR DESCRIPTION
Provisioning occasionally bumps up against the 15 minute timeout.