### PR TITLE
SQUALL-559: host managed updates

### DIFF
--- a/core/modules/qcluster/scripts/provision.py
+++ b/core/modules/qcluster/scripts/provision.py
@@ -209,6 +209,7 @@ MACAddress={mac_address}
 
 [Link]
 AlternativeName=qumulo-frontend1
+AlternativeName=qumulo-backend
 """
 
         link_unit = systemd_network / "10-qumulo-frontend-link-altname.link"

--- a/core/modules/qprovisioner/scripts/provision.py
+++ b/core/modules/qprovisioner/scripts/provision.py
@@ -289,7 +289,7 @@ def maybe_update_floating_ips(
     if not qfsd_version or int(qfsd_version.replace(".", "")[:3]) < 751:
         return
 
-    qq_command("network_v3_get_config -o network_config.json")
+    qq_command("network_get_config -o network_config.json")
 
     with open("network_config.json", "r") as f:
         current_config = json.load(f)
@@ -331,7 +331,7 @@ def maybe_update_floating_ips(
         with open("network_config.json", "w") as f:
             json.dump(current_config, f)
 
-        qq_command("network_v3_put_config --file network_config.json")
+        qq_command("network_put_config --file network_config.json")
         wait_for_new_quorum()
 
 

--- a/core/modules/qprovisioner/scripts/provision.py
+++ b/core/modules/qprovisioner/scripts/provision.py
@@ -269,8 +269,13 @@ def apply_initial_floating_ips(flips: List[str], netmask: str) -> None:
 
     while True:
         try:
-            result = qq_command("raw GET /v3/network/status")
-            if "floating_addresses" in result.stdout:
+            statuses = json.loads(qq_command("network_status").stdout.replace("'", '"'))
+            config_applied = True
+            for status in statuses:
+                if status['network_statuses']['1']['status'] != 'APPLIED':
+                    config_applied = False
+
+            if config_applied:
                 logging.info("Network configuration applied")
                 break
         except ProvisioningError:


### PR DESCRIPTION
This change requires the user to be on QC 7.6.4 or later to handle the  `network_v3_get_config` -> `network_get_config` and `network_v3_put_config` -> `network_put_config` change.

There are other modifications that could be made, as we know have a fully fleshed out CLI for host_managed networking with `network_create_network` & `network_modify_network`. But, since the JSON blob creation for the PUT is already in place, I don't see immediate value in switching to those CLI commands. 

We also directly look at the statuses of the networks to see if that are applied. This is more fine grained than the check that was there. 