### PR TITLE
Allow deploying nodes in a single fault domain in dev environment

### DIFF
--- a/core/locals.tf
+++ b/core/locals.tf
@@ -28,7 +28,7 @@ locals {
   cluster_node_ips           = join(" ", [for i in module.qcluster.nodes : i.private_ip])
   clustering_node_id         = module.qcluster.nodes[0].id
   clustering_node_ip         = module.qcluster.nodes[0].private_ip
-  node_ips_and_fault_domains = length(module.qcluster.nodes) >= 5 || length(module.qcluster.nodes) == 3 ? join(" ", [for i in module.qcluster.nodes : "${i.private_ip},${i.fault_domain}"]) : join(" ", [for i in module.qcluster.nodes : "${i.private_ip},None"])
+  node_ips_and_fault_domains = !var.single_fault_domain && (length(module.qcluster.nodes) >= 5 || length(module.qcluster.nodes) == 3) ? join(" ", [for i in module.qcluster.nodes : "${i.private_ip},${i.fault_domain}"]) : join(" ", [for i in module.qcluster.nodes : "${i.private_ip},None"])
   object_storage_uris        = join(" ", var.persistent_storage.object_storage_uris)
   product_type               = var.q_cluster_cold ? "ARCHIVE_WITH_IA_STORAGE" : "ACTIVE_WITH_STANDARD_STORAGE"
 }

--- a/core/locals.tf
+++ b/core/locals.tf
@@ -28,7 +28,7 @@ locals {
   cluster_node_ips           = join(" ", [for i in module.qcluster.nodes : i.private_ip])
   clustering_node_id         = module.qcluster.nodes[0].id
   clustering_node_ip         = module.qcluster.nodes[0].private_ip
-  node_ips_and_fault_domains = !var.single_fault_domain && (length(module.qcluster.nodes) >= 5 || length(module.qcluster.nodes) == 3) ? join(" ", [for i in module.qcluster.nodes : "${i.private_ip},${i.fault_domain}"]) : join(" ", [for i in module.qcluster.nodes : "${i.private_ip},None"])
+  node_ips_and_fault_domains = var.single_fault_domain == null && (length(module.qcluster.nodes) >= 5 || length(module.qcluster.nodes) == 3) ? join(" ", [for i in module.qcluster.nodes : "${i.private_ip},${i.fault_domain}"]) : join(" ", [for i in module.qcluster.nodes : "${i.private_ip},None"])
   object_storage_uris        = join(" ", var.persistent_storage.object_storage_uris)
   product_type               = var.q_cluster_cold ? "ARCHIVE_WITH_IA_STORAGE" : "ACTIVE_WITH_STANDARD_STORAGE"
 }

--- a/core/main.tf
+++ b/core/main.tf
@@ -324,6 +324,7 @@ module "qcluster" {
   qumulo_core_object_uri = var.qumulo_core_rpm_url
 
   availability_domain = var.availability_domain
+  single_fault_domain = var.single_fault_domain
 
   object_storage_uris         = local.object_storage_uris
   access_key_id               = var.custom_secret_key == null ? local.access_key_id : ""

--- a/core/modules/qcluster/main.tf
+++ b/core/modules/qcluster/main.tf
@@ -41,7 +41,7 @@ resource "oci_core_instance" "node" {
   count               = var.node_count
   compartment_id      = var.compartment_ocid
   availability_domain = local.availability_domain
-  fault_domain        = var.single_fault_domain ? local.fault_domains[1].name : local.fault_domains[count.index % length(local.fault_domains)].name
+  fault_domain        = var.single_fault_domain != null ? var.single_fault_domain : local.fault_domains[count.index % length(local.fault_domains)].name
   create_vnic_details {
     assign_ipv6ip             = "false"
     assign_private_dns_record = "true"

--- a/core/modules/qcluster/main.tf
+++ b/core/modules/qcluster/main.tf
@@ -41,7 +41,7 @@ resource "oci_core_instance" "node" {
   count               = var.node_count
   compartment_id      = var.compartment_ocid
   availability_domain = local.availability_domain
-  fault_domain        = local.fault_domains[count.index % length(local.fault_domains)].name
+  fault_domain        = var.single_fault_domain ? local.fault_domains[1].name : local.fault_domains[count.index % length(local.fault_domains)].name
   create_vnic_details {
     assign_ipv6ip             = "false"
     assign_private_dns_record = "true"

--- a/core/modules/qcluster/outputs.tf
+++ b/core/modules/qcluster/outputs.tf
@@ -28,7 +28,7 @@ output "nodes" {
       name         = node.display_name
       private_ip   = node.private_ip
       id           = node.id
-      fault_domain = (i % length(local.fault_domains)) + 1
+      fault_domain = var.single_fault_domain ? 1 : (i % length(local.fault_domains)) + 1
     }
   ]
 }

--- a/core/modules/qcluster/outputs.tf
+++ b/core/modules/qcluster/outputs.tf
@@ -28,7 +28,7 @@ output "nodes" {
       name         = node.display_name
       private_ip   = node.private_ip
       id           = node.id
-      fault_domain = var.single_fault_domain ? 1 : (i % length(local.fault_domains)) + 1
+      fault_domain = var.single_fault_domain != null ? 1 : (i % length(local.fault_domains)) + 1
     }
   ]
 }

--- a/core/modules/qcluster/variables.tf
+++ b/core/modules/qcluster/variables.tf
@@ -113,9 +113,10 @@ variable "availability_domain" {
 }
 
 variable "single_fault_domain" {
-  description = "Places all nodes in a single fault domain instead of distributing across fault domains."
-  type        = bool
-  default     = false
+  description = "The name of a single fault domain to place all nodes in. Leave null to distribute across fault domains."
+  type        = string
+  nullable    = true
+  default     = null
 }
 
 variable "object_storage_uris" {

--- a/core/modules/qcluster/variables.tf
+++ b/core/modules/qcluster/variables.tf
@@ -112,6 +112,12 @@ variable "availability_domain" {
   type        = string
 }
 
+variable "single_fault_domain" {
+  description = "Places all nodes in a single fault domain instead of distributing across fault domains."
+  type        = bool
+  default     = false
+}
+
 variable "object_storage_uris" {
   description = "The URIs of Oracle object storage that are backing the Qumulo cluster."
   type        = string

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -140,6 +140,12 @@ variable "dev_environment" {
   default     = false
 }
 
+variable "single_fault_domain" {
+  description = "Places all nodes in a single fault domain instead of distributing across fault domains. Requires dev_environment = true."
+  type        = bool
+  default     = false
+}
+
 variable "node_instance_shape" {
   description = "The VM shape to use for the Qumulo nodes."
   type        = string

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -141,9 +141,10 @@ variable "dev_environment" {
 }
 
 variable "single_fault_domain" {
-  description = "Places all nodes in a single fault domain instead of distributing across fault domains. Requires dev_environment = true."
-  type        = bool
-  default     = false
+  description = "The name of a single fault domain to place all nodes in. Leave null to distribute across fault domains."
+  type        = string
+  nullable    = true
+  default     = null
 }
 
 variable "node_instance_shape" {

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,7 @@ module "core" {
   source = "./core/"
 
   dev_environment                          = var.dev_environment
+  single_fault_domain                      = var.single_fault_domain
   persistent_storage                       = local.persistent_storage
   node_ssh_public_key_paths                = var.node_ssh_public_key_paths
   node_ssh_public_key_strings              = var.node_ssh_public_key_strings

--- a/variables.tf
+++ b/variables.tf
@@ -183,16 +183,10 @@ variable "dev_environment" {
 }
 
 variable "single_fault_domain" {
-  description = "Places all nodes in a single fault domain instead of distributing across fault domains. Requires dev_environment = true."
-  type        = bool
-  default     = false
-  validation {
-    condition = anytrue([
-      var.single_fault_domain == false,
-      var.dev_environment,
-    ])
-    error_message = "single_fault_domain can only be enabled when dev_environment is true."
-  }
+  description = "The name of a single fault domain to place all nodes in (e.g. \"FAULT-DOMAIN-2\"). Leave null to distribute across fault domains. Requires dev_environment = true."
+  type        = string
+  nullable    = true
+  default     = null
 }
 
 variable "node_instance_shape" {

--- a/variables.tf
+++ b/variables.tf
@@ -182,6 +182,19 @@ variable "dev_environment" {
   default     = false
 }
 
+variable "single_fault_domain" {
+  description = "Places all nodes in a single fault domain instead of distributing across fault domains. Requires dev_environment = true."
+  type        = bool
+  default     = false
+  validation {
+    condition = anytrue([
+      var.single_fault_domain == false,
+      var.dev_environment,
+    ])
+    error_message = "single_fault_domain can only be enabled when dev_environment is true."
+  }
+}
+
 variable "node_instance_shape" {
   description = "The VM shape to use for the Qumulo nodes."
   type        = string


### PR DESCRIPTION
OCI has run out of DenseIO.E4.Flex in us-phoenix-1 FD-1 for a few weeks now. The result is we are unable to deploy 3-node cluster that spreads in FD-1, FD-2, and FD-3. To be able to continue running our tests in automation, we have decided to allow deployment in a single fault domain. Only allows when dev_environment is set to true