### PR TITLE
Support for customer managed encryption keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ The Terraform state is stored locally by default. For production deployments, co
 - Changing a cluster of 3 nodes or 5 or more nodes to 4 nodes is not supported due to fault domain tolerence incompatibility, vice versa.
 - The maximum cluster soft capacity limit is 500TB per object storage bucket.
 
+## Using customer managed keys for encryption at rest
+This scripts supports the use of customer managed keys for encrypting the object storage buckets at rest.  Customer managed keys must be registered as Master Encryption Keys in the same region as the cluster deployment.  The process for deploying a customer managed key is as follows.
+### Customer managed key for persistent object storage
+- Create or import a Master Encryption Key in the same region as the deployed cluster
+- Create a policy that allows the object storage service to access the key (e.g. `Allow service objectstorage-us-phoenix-1 to use keys in compartment Security`)
+- Set the variable `object_storage_encryption_key` to the OCID of the desired key before applying the `persistent-storage` stack.
+
 ## Deploying outside the Home Region
 To deploy a cluster outside the home region, the following changes are required:
 - Update the `region` variable in `terraform.tfvars` to the region where you want to deploy the cluster.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ The Terraform state is stored locally by default. For production deployments, co
 
 ## Using customer managed keys for encryption at rest
 This scripts supports the use of customer managed keys for encrypting the object storage buckets at rest.  Customer managed keys must be registered as Master Encryption Keys in the same region as the cluster deployment.  The process for deploying a customer managed key is as follows.
+
 ### Customer managed key for persistent object storage
 - Create or import a Master Encryption Key in the same region as the deployed cluster
 - Create a policy that allows the object storage service to access the key (e.g. `Allow service objectstorage-us-phoenix-1 to use keys in compartment Security`)

--- a/README.md
+++ b/README.md
@@ -240,6 +240,13 @@ This scripts supports the use of customer managed keys for encrypting the object
 - Set the variable `object_storage_encryption_key` to the OCID of the desired key before applying the `persistent-storage` stack.
 - This variable can be changed and the stack re-applied without redeploying the persistent storage buckets.  This allows key rotation on an existing cluster's persistent object storage.
 
+### Customer managed key for node block volumes
+- Create or import a Master Encryption Key in the same region as the deployed cluster
+- Create a policy that allows the object storage service to access the key (e.g. `Allow service blockvolume to use keys in compartment Storage`)
+  - This policy can be made stricter through the use of conditions, but must allow the objeect storage service to access the selected encryption key
+- Set the variable `block_volume_encryption_key` to the OCID of the desired key before applying the main stack.
+
+
 ## Deploying outside the Home Region
 To deploy a cluster outside the home region, the following changes are required:
 - Update the `region` variable in `terraform.tfvars` to the region where you want to deploy the cluster.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ This scripts supports the use of customer managed keys for encrypting the object
 
 ### Customer managed key for persistent object storage
 - Create or import a Master Encryption Key in the same region as the deployed cluster
-- Create a policy that allows the object storage service to access the key (e.g. `Allow service objectstorage-us-phoenix-1 to use keys in compartment Security`)
+- Create a policy that allows the object storage service to access the key (e.g. `Allow service objectstorage-us-phoenix-1 to use keys in compartment Storage`)
+  - This policy can be made stricter through the use of conditions, but must allow the objeect storage service to access the selected encryption key
 - Set the variable `object_storage_encryption_key` to the OCID of the desired key before applying the `persistent-storage` stack.
 
 ## Deploying outside the Home Region

--- a/README.md
+++ b/README.md
@@ -243,8 +243,9 @@ This scripts supports the use of customer managed keys for encrypting the object
 ### Customer managed key for instance block volumes
 - Create or import a Master Encryption Key in the same region as the deployed cluster
 - Create a policy statement that allows the object storage service to access the key (e.g. `Allow service blockstorage to use keys in compartment Storage`)
-  - This policy can be made stricter through the use of conditions, but must allow the objeect storage service to access the selected encryption key
+  - This policy can be made stricter through the use of conditions, but must allow the block storage service to access the selected encryption key
 - Set the variable `block_volume_encryption_key` to the OCID of the desired key before applying the main stack.
+- Chaging the Block Volume encryption keys after deployment is not supported.
 
 
 ## Deploying outside the Home Region

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ This scripts supports the use of customer managed keys for encrypting the object
 ### Customer managed key for persistent object storage
 - Create or import a Master Encryption Key in the same region as the deployed cluster
 - Create a policy statement that allows the object storage service to access the key (e.g. `Allow service objectstorage-us-phoenix-1 to use keys in compartment Storage`)
-  - This policy can be made stricter through the use of conditions, but must allow the objeect storage service to access the selected encryption key
+  - This policy can be made stricter through the use of conditions, but must allow the object storage service to access the selected encryption key
 - Set the variable `object_storage_encryption_key` to the OCID of the desired key before applying the `persistent-storage` stack.
 - This variable can be changed and the stack re-applied without redeploying the persistent storage buckets.  This allows key rotation on an existing cluster's persistent object storage.
 
@@ -245,7 +245,7 @@ This scripts supports the use of customer managed keys for encrypting the object
 - Create a policy statement that allows the object storage service to access the key (e.g. `Allow service blockstorage to use keys in compartment Storage`)
   - This policy can be made stricter through the use of conditions, but must allow the block storage service to access the selected encryption key
 - Set the variable `block_volume_encryption_key` to the OCID of the desired key before applying the main stack.
-- Chaging the Block Volume encryption keys after deployment is not supported.
+- Changing the Block Volume encryption keys after deployment is not supported.
 
 
 ## Deploying outside the Home Region

--- a/README.md
+++ b/README.md
@@ -231,18 +231,18 @@ The Terraform state is stored locally by default. For production deployments, co
 - The maximum cluster soft capacity limit is 500TB per object storage bucket.
 
 ## Using customer managed keys for encryption at rest
-This scripts supports the use of customer managed keys for encrypting the object storage buckets at rest.  Customer managed keys must be registered as Master Encryption Keys in the same region as the cluster deployment.  The process for deploying a customer managed key is as follows.
+This scripts supports the use of customer managed keys for encrypting the object storage buckets and the block volumes attached to cluster and provisioner instances at rest.  Customer managed keys must be registered as Master Encryption Keys in the same region as the cluster deployment.  The process for deploying customer managed keys is as follows.
 
 ### Customer managed key for persistent object storage
 - Create or import a Master Encryption Key in the same region as the deployed cluster
-- Create a policy that allows the object storage service to access the key (e.g. `Allow service objectstorage-us-phoenix-1 to use keys in compartment Storage`)
+- Create a policy statement that allows the object storage service to access the key (e.g. `Allow service objectstorage-us-phoenix-1 to use keys in compartment Storage`)
   - This policy can be made stricter through the use of conditions, but must allow the objeect storage service to access the selected encryption key
 - Set the variable `object_storage_encryption_key` to the OCID of the desired key before applying the `persistent-storage` stack.
 - This variable can be changed and the stack re-applied without redeploying the persistent storage buckets.  This allows key rotation on an existing cluster's persistent object storage.
 
-### Customer managed key for node block volumes
+### Customer managed key for instance block volumes
 - Create or import a Master Encryption Key in the same region as the deployed cluster
-- Create a policy that allows the object storage service to access the key (e.g. `Allow service blockvolume to use keys in compartment Storage`)
+- Create a policy statement that allows the object storage service to access the key (e.g. `Allow service blockstorage to use keys in compartment Storage`)
   - This policy can be made stricter through the use of conditions, but must allow the objeect storage service to access the selected encryption key
 - Set the variable `block_volume_encryption_key` to the OCID of the desired key before applying the main stack.
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ This scripts supports the use of customer managed keys for encrypting the object
 - Create a policy that allows the object storage service to access the key (e.g. `Allow service objectstorage-us-phoenix-1 to use keys in compartment Storage`)
   - This policy can be made stricter through the use of conditions, but must allow the objeect storage service to access the selected encryption key
 - Set the variable `object_storage_encryption_key` to the OCID of the desired key before applying the `persistent-storage` stack.
+- This variable can be changed and the stack re-applied without redeploying the persistent storage buckets.  This allows key rotation on an existing cluster's persistent object storage.
 
 ## Deploying outside the Home Region
 To deploy a cluster outside the home region, the following changes are required:

--- a/core/main.tf
+++ b/core/main.tf
@@ -307,11 +307,12 @@ module "qcluster" {
   compartment_ocid = var.compartment_ocid
   subnet_ocid      = var.subnet_ocid
 
-  node_count           = var.q_node_count
-  permanent_disk_count = local.permanent_disk_count
-  floating_ip_count    = var.q_cluster_floating_ips
-  persisted_node_count = tonumber(data.external.cluster_node_count.result.value)
-  persisted_disk_count = tonumber(data.external.deployed_permanent_disk_count.result.value)
+  node_count                  = var.q_node_count
+  permanent_disk_count        = local.permanent_disk_count
+  block_volume_encryption_key = var.block_volume_encryption_key
+  floating_ip_count           = var.q_cluster_floating_ips
+  persisted_node_count        = tonumber(data.external.cluster_node_count.result.value)
+  persisted_disk_count        = tonumber(data.external.deployed_permanent_disk_count.result.value)
 
   node_instance_shape = var.node_instance_shape
   node_instance_ocpus = var.node_instance_ocpus
@@ -323,10 +324,10 @@ module "qcluster" {
 
   qumulo_core_object_uri = var.qumulo_core_rpm_url
 
-  multi_ad_deployment = var.multi_ad_deployment
-  availability_domain = var.availability_domain
+  multi_ad_deployment       = var.multi_ad_deployment
+  availability_domain       = var.availability_domain
   availability_domain_names = local.availability_domain_names
-  single_fault_domain = var.single_fault_domain
+  single_fault_domain       = var.single_fault_domain
 
   object_storage_uris         = local.object_storage_uris
   access_key_id               = var.custom_secret_key == null ? local.access_key_id : ""
@@ -350,11 +351,12 @@ module "qprovisioner" {
   compartment_ocid = var.compartment_ocid
   subnet_ocid      = var.subnet_ocid
 
-  node_count           = var.q_cluster_node_count
-  permanent_disk_count = local.permanent_disk_count
-  instance_shape       = var.provisioner_instance_shape
-  instance_ocpus       = var.provisioner_instance_ocpus
-  assign_public_ip     = var.assign_public_ip
+  node_count                  = var.q_cluster_node_count
+  permanent_disk_count        = local.permanent_disk_count
+  instance_shape              = var.provisioner_instance_shape
+  instance_ocpus              = var.provisioner_instance_ocpus
+  assign_public_ip            = var.assign_public_ip
+  block_volume_encryption_key = var.block_volume_encryption_key
 
   instance_ssh_public_key_paths   = var.node_ssh_public_key_paths
   instance_ssh_public_key_strings = var.node_ssh_public_key_strings

--- a/core/modules/qcluster-disk/main.tf
+++ b/core/modules/qcluster-disk/main.tf
@@ -29,6 +29,7 @@ resource "oci_core_volume" "permanent_disk" {
   display_name        = "${var.deployment_unique_name}-${var.node_id + 1}-permanent-disk-${count.index + 1}"
   size_in_gbs         = var.size_in_gbs
   vpus_per_gb         = var.vpus_per_gb
+  kms_key_id          = var.block_volume_encryption_key
   defined_tags        = length(var.defined_tags) > 0 ? var.defined_tags : null
   freeform_tags       = var.freeform_tags
 

--- a/core/modules/qcluster-disk/variables.tf
+++ b/core/modules/qcluster-disk/variables.tf
@@ -32,6 +32,11 @@ variable "persisted_disk_count" {
   type        = number
 }
 
+variable "block_volume_encryption_key" {
+  description = "The OCID of the Master Encryption Key to use for block volume encryption at rest."
+  type        = string
+}
+
 variable "availability_domain" {
   description = "The availability domain to be used for the cluster resources."
   type        = string

--- a/core/modules/qcluster/main.tf
+++ b/core/modules/qcluster/main.tf
@@ -86,7 +86,7 @@ resource "oci_core_instance" "node" {
     source_type             = "image"
     boot_volume_size_in_gbs = 256
     boot_volume_vpus_per_gb = 30
-    # kms_key_id              = var.block_volume_encryption_key
+    kms_key_id              = var.block_volume_encryption_key
   }
 
   lifecycle {

--- a/core/modules/qcluster/main.tf
+++ b/core/modules/qcluster/main.tf
@@ -86,6 +86,7 @@ resource "oci_core_instance" "node" {
     source_type             = "image"
     boot_volume_size_in_gbs = 256
     boot_volume_vpus_per_gb = 30
+    # kms_key_id              = var.block_volume_encryption_key
   }
 
   lifecycle {
@@ -136,15 +137,16 @@ module "disk" {
   count  = var.node_count
   source = "../qcluster-disk"
 
-  availability_domain    = local.instance_placement[count.index].availability_domain
-  compartment_ocid       = var.compartment_ocid
-  deployment_unique_name = var.deployment_unique_name
-  instance_id            = oci_core_instance.node[count.index].id
-  node_id                = count.index
-  disk_count             = var.permanent_disk_count
-  persisted_disk_count   = var.persisted_disk_count
-  size_in_gbs            = "270"
-  vpus_per_gb            = "10"
-  defined_tags           = var.defined_tags
-  freeform_tags          = var.freeform_tags
+  availability_domain         = local.instance_placement[count.index].availability_domain
+  compartment_ocid            = var.compartment_ocid
+  deployment_unique_name      = var.deployment_unique_name
+  instance_id                 = oci_core_instance.node[count.index].id
+  node_id                     = count.index
+  disk_count                  = var.permanent_disk_count
+  persisted_disk_count        = var.persisted_disk_count
+  size_in_gbs                 = "270"
+  vpus_per_gb                 = "10"
+  block_volume_encryption_key = var.block_volume_encryption_key
+  defined_tags                = var.defined_tags
+  freeform_tags               = var.freeform_tags
 }

--- a/core/modules/qcluster/variables.tf
+++ b/core/modules/qcluster/variables.tf
@@ -67,6 +67,11 @@ variable "persisted_disk_count" {
   type        = number
 }
 
+variable "block_volume_encryption_key" {
+  description = "The OCID of the Master Encryption Key to use for block volume encryption at rest."
+  type        = string
+}
+
 variable "node_instance_shape" {
   description = "The VM shape to use for the Qumulo nodes."
   type        = string

--- a/core/modules/qprovisioner/main.tf
+++ b/core/modules/qprovisioner/main.tf
@@ -88,6 +88,7 @@ resource "oci_core_instance" "provisioner" {
     source_id               = data.oci_core_images.base_image.images[0].id
     source_type             = "image"
     boot_volume_vpus_per_gb = 20
+    kms_key_id              = var.block_volume_encryption_key
   }
   instance_options {
     are_legacy_imds_endpoints_disabled = true

--- a/core/modules/qprovisioner/variables.tf
+++ b/core/modules/qprovisioner/variables.tf
@@ -79,6 +79,11 @@ variable "instance_ssh_public_key_strings" {
   type        = list(string)
 }
 
+variable "block_volume_encryption_key" {
+  description = "The OCID of the Master Encryption Key to use for block volume encryption at rest."
+  type        = string
+}
+
 variable "cluster_node_ip_addresses" {
   description = "The private IP addresses for the nodes in the Qumulo cluster."
   type        = string

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -190,6 +190,17 @@ variable "block_volume_count" {
   }
 }
 
+variable "block_volume_encryption_key" {
+  description = "The OCID of the Master Encryption Key to use for block volume encryption at rest."
+  type        = string
+  default     = null
+  nullable    = true
+  validation {
+    condition     = var.block_volume_encryption_key == null || substr(var.block_volume_encryption_key, 0, 14) == "ocid1.key.oc1."
+    error_message = "block_volume_encryption_key must either be null or begin with ocid1.key.oc1."
+  }
+}
+
 variable "vault_ocid" {
   description = "The OCID of an existing vault to be used to store the cluster secrets."
   type        = string

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ module "core" {
   node_base_image                          = var.node_base_image
   assign_public_ip                         = var.assign_public_ip
   block_volume_count                       = var.block_volume_count
+  block_volume_encryption_key              = var.block_volume_encryption_key
   vault_ocid                               = var.vault_ocid
   qumulo_core_rpm_url                      = var.qumulo_core_rpm_url
   q_cluster_admin_password                 = var.q_cluster_admin_password

--- a/persistent-storage/main.tf
+++ b/persistent-storage/main.tf
@@ -111,6 +111,7 @@ resource "oci_objectstorage_bucket" "bucket" {
   compartment_id = var.compartment_ocid
   name           = "${local.deployment_unique_name}-bucket-${count.index + 1}"
   namespace      = local.namespace
+  kms_key_id     = var.object_storage_encryption_key
   freeform_tags  = var.freeform_tags
   defined_tags   = length(var.defined_tags) > 0 ? var.defined_tags : null
 

--- a/persistent-storage/variables.tf
+++ b/persistent-storage/variables.tf
@@ -66,6 +66,17 @@ variable "object_storage_bucket_count" {
   }
 }
 
+variable "object_storage_encryption_key" {
+  description = "The OCID of the Master Encryption Key to use for bucket encryption at rest."
+  type        = string
+  default     = null
+  nullable    = true
+  validation {
+    condition     = var.object_storage_encryption_key == null || substr(var.object_storage_encryption_key, 0, 13) == "ocid1.key.oc1."
+    error_message = "object_storage_encryption_key must either be null or begin with ocid1.key.oc1."
+  }
+}
+
 variable "region" {
   description = "The OCI region that you want to deploy into. EX: us-phoenix-1"
   type        = string

--- a/persistent-storage/variables.tf
+++ b/persistent-storage/variables.tf
@@ -72,7 +72,7 @@ variable "object_storage_encryption_key" {
   default     = null
   nullable    = true
   validation {
-    condition     = var.object_storage_encryption_key == null || substr(var.object_storage_encryption_key, 0, 13) == "ocid1.key.oc1."
+    condition     = var.object_storage_encryption_key == null || substr(var.object_storage_encryption_key, 0, 14) == "ocid1.key.oc1."
     error_message = "object_storage_encryption_key must either be null or begin with ocid1.key.oc1."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -232,6 +232,17 @@ variable "block_volume_count" {
   }
 }
 
+variable "block_volume_encryption_key" {
+  description = "The OCID of the Master Encryption Key to use for block volume encryption at rest."
+  type        = string
+  default     = null
+  nullable    = true
+  validation {
+    condition     = var.block_volume_encryption_key == null || substr(var.block_volume_encryption_key, 0, 14) == "ocid1.key.oc1."
+    error_message = "block_volume_encryption_key must either be null or begin with ocid1.key.oc1."
+  }
+}
+
 variable "vault_ocid" {
   description = "The OCID of an existing vault to be used to store the cluster secrets."
   type        = string


### PR DESCRIPTION
Adds support for customer managed encryption keys for the following resource types

- Object Storage buckets
- Block Volumes
- Boot Volumes
 
New variables `object_storage_encryption_key` and `block_volume_encryption_key` lets user specify OCIDs of Master Encryption Keys in the deployment Region to be applied to the relevant resources.  Master Encryption Keys can be generated within the Secrets Vault panel or imported into the Vault, allowing the use of keys from a KMS outside of OCI.   The default for these variables is `null` which will use OCI Managed Keys for the created resources.  New functionality is fully documented in the top level README.md file.