### PR TITLE
Support for non-home region deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ To deploy a cluster outside the home region, the follwing requrements must be sa
 - Update the region for the DEFAULT profile in your `~/.oci/config` file to the region the cluster will be deployed.
 - Add the variable `home_region` to the top level `terraform.tfvars` file and set it to the home region of the deployment tenancy.
 - Because of extended IAM replication times between regions, consider increasing the values of `object_storage_access_delay` and `provisioner_wait_for_completion_max_retries`, especially when using a non-default identity domain.
+- If using Identity Domain based IAM resources, ensure that replication to the target domain is enabled.
 
 ## Upgrading from previous versions of this Terraform
 When upgrading from release 2.4.0 or earlier, the following changes must be made to prevent cluster redeployment

--- a/README.md
+++ b/README.md
@@ -263,12 +263,11 @@ This scripts supports the use of customer managed keys for encrypting the object
 
 
 ## Deploying outside the Home Region
-To deploy a cluster outside the home region, the following changes are required:
-- Update the `region` variable in `terraform.tfvars` to the region where you want to deploy the cluster.
-- Update the region for the DEFAULT profile in your `~/.oci/config` file to the region where you want to deploy the cluster.
-- Update the `subnet_ocid` variable in `terraform.tfvars` to the subnet OCID of the subnet where you want to deploy the cluster.
+To deploy a cluster outside the home region, the follwing requrements must be satisfied:
 - The Secrets Vaults for the cluster and persistent storage must be in the same region as the cluster.
-- You must use a precreated dynamic group and identity policy created in the home region for the cluster.  Set `create_dynamic_group_and_identity_policy` to `false` in `terraform.tfvars`.  Follow the instruction in the [Prerequisites](#prerequisites) section 4.B to create the dynamic group and identity policy.
+- Update the region for the DEFAULT profile in your `~/.oci/config` file to the region the cluster will be deployed.
+- Add the variable `home_region` to the top level `terraform.tfvars` file and set it to the home region of the deployment tenancy.
+- Because of extended IAM replication times between regions, consider increasing the values of `object_storage_access_delay` and `provisioner_wait_for_completion_max_retries`, especially when using a non-default identity domain.
 
 ## Upgrading from previous versions of this Terraform
 When upgrading from release 2.4.0 or earlier, the following changes must be made to prevent cluster redeployment

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ This scripts supports the use of customer managed keys for encrypting the object
 
 ### Customer managed key for persistent object storage
 - Create or import a Master Encryption Key in the same region as the deployed cluster
-- Create a policy statement that allows the object storage service to access the key (e.g. `Allow service objectstorage-us-phoenix-1 to use keys in compartment Storage`)
+- Create a policy statement that allows the object storage service in the deployment region to access the key (e.g. `Allow service objectstorage-us-phoenix-1 to use keys in compartment Storage`)
   - This policy can be made stricter through the use of conditions, but must allow the object storage service to access the selected encryption key
 - Set the variable `object_storage_encryption_key` to the OCID of the desired key before applying the `persistent-storage` stack.
 - This variable can be changed and the stack re-applied without redeploying the persistent storage buckets.  This allows key rotation on an existing cluster's persistent object storage.

--- a/core/main.tf
+++ b/core/main.tf
@@ -134,6 +134,18 @@ resource "oci_identity_policy" "classic_cluster_policy" {
   ]
 }
 
+# Skipped if create_dynamic_group_and_identity_policy is false
+resource "oci_identity_dynamic_group" "instance_dynamic_group" {
+  provider       = oci.home-region
+  count          = var.create_dynamic_group_and_identity_policy && var.persistent_storage_access_model.access_style != "domain" ? 1 : 0
+  compartment_id = var.tenancy_ocid
+  name           = "${local.deployment_unique_name}-instance-dynamic-group"
+  description    = "The dynamic group used by the ${local.deployment_unique_name} Qumulo cluster to obtain instance privileges."
+  matching_rule  = "instance.compartment.id = '${var.compartment_ocid}'"
+  defined_tags   = length(var.defined_tags) > 0 ? var.defined_tags : null
+  freeform_tags  = var.freeform_tags
+}
+
 
 # Domain access model Resources
 locals {
@@ -286,18 +298,56 @@ resource "oci_identity_policy" "domain_cluster_policy" {
   ]
 }
 
+# Skipped if create_dynamic_group_and_identity_policy is false
+resource "oci_identity_domains_dynamic_resource_group" "domain_instance_dynamic_group" {
+  provider = oci.home-region
+  count    = var.create_dynamic_group_and_identity_policy && var.persistent_storage_access_model.access_style == "domain" ? 1 : 0
 
-# Node access Dynamic Group and Policy
-#   Skipped if create_dynamic_group_and_identity_policy is false
-resource "oci_identity_dynamic_group" "instance_dynamic_group" {
-  provider       = oci.home-region
-  count          = var.create_dynamic_group_and_identity_policy ? 1 : 0
-  compartment_id = var.tenancy_ocid
-  name           = "${local.deployment_unique_name}-instance-dynamic-group"
-  description    = "The dynamic group used by the ${local.deployment_unique_name} Qumulo cluster to obtain instance privileges."
-  matching_rule  = "instance.compartment.id = '${var.compartment_ocid}'"
-  defined_tags   = length(var.defined_tags) > 0 ? var.defined_tags : null
-  freeform_tags  = var.freeform_tags
+  schemas = [
+    "urn:ietf:params:scim:schemas:oracle:idcs:DynamicResourceGroup",
+    "urn:ietf:params:scim:schemas:oracle:idcs:extension:OCITags",
+  ]
+  attributes    = "tags"
+  idcs_endpoint = var.persistent_storage_access_model.domain_idcs_endpoint
+  display_name  = "${local.deployment_unique_name}-instance-dynamic-group"
+  description   = "The dynamic group used by the ${local.deployment_unique_name} Qumulo cluster to obtain instance privileges."
+  matching_rule = "instance.compartment.id = '${var.compartment_ocid}'"
+  urnietfparamsscimschemasoracleidcsextension_oci_tags {
+    dynamic "defined_tags" {
+      for_each = { for i, t in local.idc_defined_tag_list : "${t.namespace}.${t.key}" => t }
+      content {
+        namespace = defined_tags.value.namespace
+        key       = defined_tags.value.key
+        value     = defined_tags.value.value
+      }
+    }
+
+    dynamic "freeform_tags" {
+      for_each = { for t in local.idc_freeform_tag_list : t.key => t }
+      content {
+        key   = freeform_tags.value.key
+        value = freeform_tags.value.value
+      }
+    }
+  }
+  lifecycle {
+    ignore_changes = [
+      schemas,
+      attributes,
+      idcs_endpoint,
+      urnietfparamsscimschemasoracleidcsextension_oci_tags
+    ]
+  }
+}
+
+# Instance access Policies
+# Skipped if create_dynamic_group_and_identity_policy is false
+locals {
+  instance_dynamic_group_policy_subject = var.create_dynamic_group_and_identity_policy ? (
+    var.persistent_storage_access_model.access_style == "domain"
+    ? "'${var.persistent_storage_access_model.domain_identity_domain_display_name}'/'${oci_identity_domains_dynamic_resource_group.domain_instance_dynamic_group[0].display_name}'"
+    : oci_identity_dynamic_group.instance_dynamic_group[0].name
+  ) : null
 }
 
 resource "oci_identity_policy" "instance_policy" {
@@ -310,9 +360,9 @@ resource "oci_identity_policy" "instance_policy" {
   freeform_tags  = var.freeform_tags
 
   statements = [
-    "Allow dynamic-group ${oci_identity_dynamic_group.instance_dynamic_group[0].name} to read secret-bundles in compartment id ${var.compartment_ocid}",
-    "Allow dynamic-group ${oci_identity_dynamic_group.instance_dynamic_group[0].name} to use secrets in compartment id ${var.compartment_ocid}",
-    "Allow dynamic-group ${oci_identity_dynamic_group.instance_dynamic_group[0].name} to use instances in compartment id ${var.compartment_ocid}"
+    "Allow dynamic-group ${local.instance_dynamic_group_policy_subject} to read secret-bundles in compartment id ${var.compartment_ocid}",
+    "Allow dynamic-group ${local.instance_dynamic_group_policy_subject} to use secrets in compartment id ${var.compartment_ocid}",
+    "Allow dynamic-group ${local.instance_dynamic_group_policy_subject} to use instances in compartment id ${var.compartment_ocid}"
   ]
 }
 
@@ -326,9 +376,10 @@ resource "oci_identity_policy" "subnet_policy" {
   freeform_tags  = var.freeform_tags
 
   statements = [
-    "Allow dynamic-group ${oci_identity_dynamic_group.instance_dynamic_group[0].name} to use virtual-network-family in compartment id ${data.oci_core_subnet.cluster_subnet.compartment_id}",
+    "Allow dynamic-group ${local.instance_dynamic_group_policy_subject} to use virtual-network-family in compartment id ${data.oci_core_subnet.cluster_subnet.compartment_id}",
   ]
 }
+
 
 # Vault Master Encryption Key
 #   Skipped if vault_key_ocid is provided

--- a/core/main.tf
+++ b/core/main.tf
@@ -86,6 +86,7 @@ moved {
 
 # Classic access model Resources
 resource "oci_identity_user" "classic_cluster_user" {
+  provider       = oci.home-region
   count          = var.persistent_storage_access_model.access_style == "classic" ? 1 : 0
   compartment_id = var.tenancy_ocid
   name           = "${local.deployment_unique_name}-user"
@@ -96,12 +97,14 @@ resource "oci_identity_user" "classic_cluster_user" {
 }
 
 resource "oci_identity_customer_secret_key" "classic_cluster_secret_key" {
+  provider     = oci.home-region
   count        = var.persistent_storage_access_model.access_style == "classic" ? 1 : 0
   user_id      = oci_identity_user.classic_cluster_user[0].id
   display_name = "${local.deployment_unique_name}-secret-key"
 }
 
 resource "oci_identity_group" "classic_cluster_identity_group" {
+  provider       = oci.home-region
   count          = var.persistent_storage_access_model.access_style == "classic" ? 1 : 0
   compartment_id = var.tenancy_ocid
   description    = "The identity group used by the ${local.deployment_unique_name} Qumulo cluster to authenticate to object storage buckets."
@@ -111,12 +114,14 @@ resource "oci_identity_group" "classic_cluster_identity_group" {
 }
 
 resource "oci_identity_user_group_membership" "classic_cluster_group_membership" {
+  provider = oci.home-region
   count    = var.persistent_storage_access_model.access_style == "classic" ? 1 : 0
   group_id = oci_identity_group.classic_cluster_identity_group[0].id
   user_id  = oci_identity_user.classic_cluster_user[0].id
 }
 
 resource "oci_identity_policy" "classic_cluster_policy" {
+  provider       = oci.home-region
   count          = var.persistent_storage_access_model.access_style == "classic" ? 1 : 0
   compartment_id = var.compartment_ocid
   description    = "The identity policy used by the ${local.deployment_unique_name} Qumulo cluster to authenticate to object storage buckets."
@@ -148,7 +153,8 @@ locals {
 }
 
 resource "oci_identity_domains_user" "domain_cluster_user" {
-  count = var.persistent_storage_access_model.access_style == "domain" ? 1 : 0
+  provider = oci.home-region
+  count    = var.persistent_storage_access_model.access_style == "domain" ? 1 : 0
 
   schemas = [
     "urn:ietf:params:scim:schemas:core:2.0:User",
@@ -215,6 +221,7 @@ resource "oci_identity_domains_user" "domain_cluster_user" {
 }
 
 resource "oci_identity_domains_customer_secret_key" "domain_cluster_secret_key" {
+  provider      = oci.home-region
   count         = var.persistent_storage_access_model.access_style == "domain" ? 1 : 0
   idcs_endpoint = var.persistent_storage_access_model.domain_idcs_endpoint
   schemas       = ["urn:ietf:params:scim:schemas:oracle:idcs:customerSecretKey"]
@@ -225,7 +232,8 @@ resource "oci_identity_domains_customer_secret_key" "domain_cluster_secret_key" 
 }
 
 resource "oci_identity_domains_group" "domain_cluster_identity_group" {
-  count = var.persistent_storage_access_model.access_style == "domain" ? 1 : 0
+  provider = oci.home-region
+  count    = var.persistent_storage_access_model.access_style == "domain" ? 1 : 0
   schemas = [
     "urn:ietf:params:scim:schemas:core:2.0:Group",
     "urn:ietf:params:scim:schemas:oracle:idcs:extension:OCITags",
@@ -265,6 +273,7 @@ resource "oci_identity_domains_group" "domain_cluster_identity_group" {
 }
 
 resource "oci_identity_policy" "domain_cluster_policy" {
+  provider       = oci.home-region
   count          = var.persistent_storage_access_model.access_style == "domain" ? 1 : 0
   compartment_id = var.compartment_ocid
   description    = "The identity policy used by the ${local.deployment_unique_name} Qumulo cluster to authenticate to object storage buckets."
@@ -281,6 +290,7 @@ resource "oci_identity_policy" "domain_cluster_policy" {
 # Node access Dynamic Group and Policy
 #   Skipped if create_dynamic_group_and_identity_policy is false
 resource "oci_identity_dynamic_group" "instance_dynamic_group" {
+  provider       = oci.home-region
   count          = var.create_dynamic_group_and_identity_policy ? 1 : 0
   compartment_id = var.tenancy_ocid
   name           = "${local.deployment_unique_name}-instance-dynamic-group"
@@ -291,6 +301,7 @@ resource "oci_identity_dynamic_group" "instance_dynamic_group" {
 }
 
 resource "oci_identity_policy" "instance_policy" {
+  provider       = oci.home-region
   count          = var.create_dynamic_group_and_identity_policy ? 1 : 0
   compartment_id = var.compartment_ocid
   description    = "The identity policy used by the ${local.deployment_unique_name} Qumulo cluster to retrieve and manage resources related to the instances."
@@ -306,6 +317,7 @@ resource "oci_identity_policy" "instance_policy" {
 }
 
 resource "oci_identity_policy" "subnet_policy" {
+  provider       = oci.home-region
   count          = var.create_dynamic_group_and_identity_policy ? 1 : 0
   compartment_id = data.oci_core_subnet.cluster_subnet.compartment_id
   description    = "The identity policy used by the ${local.deployment_unique_name} Qumulo cluster to manage resources related to the host subnet."

--- a/core/versions.tf
+++ b/core/versions.tf
@@ -26,8 +26,9 @@ terraform {
   required_version = ">= 1.12.2"
   required_providers {
     oci = {
-      source  = "oracle/oci"
-      version = ">= 8.0.0"
+      source                = "oracle/oci"
+      version               = ">= 8.0.0"
+      configuration_aliases = [oci.home-region]
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,11 @@
 module "core" {
   source = "./core/"
 
+  providers = {
+    oci             = oci
+    oci.home-region = oci.home-region
+  }
+
   dev_environment                             = var.dev_environment
   multi_ad_deployment                         = var.multi_ad_deployment
   single_fault_domain                         = var.single_fault_domain

--- a/provider.tf
+++ b/provider.tf
@@ -33,6 +33,18 @@ provider "oci" {
   fingerprint         = var.oci_fingerprint
 }
 
+provider "oci" {
+  alias               = "home-region"
+  tenancy_ocid        = var.tenancy_ocid
+  region              = var.home_region != null ? var.home_region : var.region
+  user_ocid           = var.user_ocid
+  auth                = var.oci_auth
+  config_file_profile = var.oci_profile
+  private_key         = var.oci_private_key
+  private_key_path    = var.oci_private_key_path
+  fingerprint         = var.oci_fingerprint
+}
+
 #
 # Users should modify this state to reflect a remote backend as appropriate if
 # they modify the persistent-storage directory and the provider backend

--- a/variables.tf
+++ b/variables.tf
@@ -455,7 +455,7 @@ variable "multi_ad_deployment" {
 }
 
 variable "provisioner_wait_for_completion_max_retries" {
-  description = "The maximum number of retries to wait for the provisioner to complete."
+  description = "The maximum number of retries to wait for the provisioner to complete.  Each retry is 30 seconds."
   type        = number
   default     = 60
 }

--- a/variables.tf
+++ b/variables.tf
@@ -103,6 +103,13 @@ variable "region" {
   nullable    = false
 }
 
+variable "home_region" {
+  description = "The OCI home region for the tenancy.  Used for deployment of identity resources. EX: us-phoenix-1"
+  type        = string
+  nullable    = true
+  default     = null
+}
+
 variable "compartment_ocid" {
   description = "The compartment into which you want your Qumulo cluster deployed."
   type        = string


### PR DESCRIPTION
- Adds support for deployment into non-home regions without having to pre-deploy IAM resources.  
 - Process:
    - Set terraform variables as required for non-home region deployment
    - Add variable `home_region` set to the tenancy's home region
 - This will create the IAM resources in the home region and deploy the cluster as expected
 - Supports both default and non-default Identity Domains
 - Documentation covers requirements and important considerations for non-home region deployment
  